### PR TITLE
Format AWS_SESSION_EXPIRATION as a RFC3339 timestamp.

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -90,7 +90,7 @@ func (ap *AWSPlugin) GenerateEnvironment() (*models.ModelsEnvironmentResponse, e
 			AWSAccessKeyIDEnvVar:     *output.Credentials.AccessKeyId,
 			AWSSecretAccessKeyEnvVar: *output.Credentials.SecretAccessKey,
 			AWSSessionTokenEnvVar:    *output.Credentials.SessionToken,
-			AWSSessionExpiryEnvVar:   output.Credentials.Expiration.String(),
+			AWSSessionExpiryEnvVar:   output.Credentials.Expiration.Format(time.RFC3339),
 			AWSRegionEnvVar:          ap.awsRegion,
 		},
 	}, nil

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -51,7 +51,7 @@ func TestGenerateEnvironment(t *testing.T) {
 					aws.AWSAccessKeyIDEnvVar:     accessKeyId,
 					aws.AWSSecretAccessKeyEnvVar: secretAccessKey,
 					aws.AWSRegionEnvVar:          "test-region",
-					aws.AWSSessionExpiryEnvVar:   expiration.String(),
+					aws.AWSSessionExpiryEnvVar:   expiration.Format(time.RFC3339),
 					aws.AWSSessionTokenEnvVar:    sessionToken,
 				},
 			},


### PR DESCRIPTION
Addresses #35