### PR TITLE
Issue/30 prompt for passphrase if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Binaries cross compiled for various OS's and architectures are available in the 
 ```shell
 docker compose up --build -d
 ```
-c
+
 ### Release
 
 - Checkout the `main` branch

--- a/README.md
+++ b/README.md
@@ -175,11 +175,14 @@ $ make
 
 Binaries cross compiled for various OS's and architectures are available in the `builds/` directory.
 
-* If you have a valid `cludod.yaml` file in `~/.cludod` then a local copy of the server can be built and spun up with:
+- If you have a valid `cludod.yaml` file in `~/.cludod` then a local copy of the server can be built and spun up with:
 
 ```shell
 docker compose up --build -d
 ```
+
+- You can run the CLI in a container using something like this:
+  - `docker run -ti -v ${PWD}/data/cludo.yaml:/root/.cludo/cludo.yaml -v ${PWD}/data/id_rsa_TEST_KEY_PP:/app/id_rsa_TEST_KEY_PP ${IMAGE_ID} "cludo shell"`
 
 ### Release
 

--- a/README.md
+++ b/README.md
@@ -162,11 +162,25 @@ These values can also be set on the command line via options on the command.
 To build/test `cludo`/`cludod`:
 
 ```shell
-make
+# Only build the binaries (for all platforms)
+$ make build
+```
+
+OR
+
+```shell
+# Build the binaries and containers (for all platforms)
+$ make
 ```
 
 Binaries cross compiled for various OS's and architectures are available in the `builds/` directory.
 
+* If you have a valid `cludod.yaml` file in `~/.cludod` then a local copy of the server can be built and spun up with:
+
+```shell
+docker compose up --build -d
+```
+c
 ### Release
 
 - Checkout the `main` branch

--- a/cludo/root.go
+++ b/cludo/root.go
@@ -34,6 +34,9 @@ func MakeRootCmd(exit func(int)) (*cobra.Command, error) {
 	// Register flags bound to viper.
 	rootCmd.PersistentFlags().String("target", "", "URL of server appended with the role name")
 	viper.BindPFlag("target", rootCmd.PersistentFlags().Lookup("target"))
+	rootCmd.PersistentFlags().Bool("interactive", true, "Should the CLI prompt the user for input")
+	viper.BindPFlag("client.default.interactive", rootCmd.PersistentFlags().Lookup("interactive"))
+>>>>>>> b6b2438 (non-interactive mode)
 	rootCmd.PersistentFlags().StringP("key-path", "k", "~/.ssh/id_rsa", "Path to SSH private key")
 	viper.BindPFlag("client.key_path", rootCmd.PersistentFlags().Lookup("key-path"))
 	rootCmd.PersistentFlags().StringP("passphrase", "a", "", "Passphrase for private key (consider using config or setting CLUDO_PASSPHRASE)")

--- a/cludo/root.go
+++ b/cludo/root.go
@@ -36,7 +36,6 @@ func MakeRootCmd(exit func(int)) (*cobra.Command, error) {
 	viper.BindPFlag("target", rootCmd.PersistentFlags().Lookup("target"))
 	rootCmd.PersistentFlags().Bool("interactive", true, "Should the CLI prompt the user for input")
 	viper.BindPFlag("client.default.interactive", rootCmd.PersistentFlags().Lookup("interactive"))
->>>>>>> b6b2438 (non-interactive mode)
 	rootCmd.PersistentFlags().StringP("key-path", "k", "~/.ssh/id_rsa", "Path to SSH private key")
 	viper.BindPFlag("client.key_path", rootCmd.PersistentFlags().Lookup("key-path"))
 	rootCmd.PersistentFlags().StringP("passphrase", "a", "", "Passphrase for private key (consider using config or setting CLUDO_PASSPHRASE)")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,11 +8,7 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - ./data/cludo.yaml:/etc/cludod/cludo.yaml
+      - ${HOME}/.cludod/cludod.yaml:/etc/cludod/cludod.yaml
     stdin_open: true
-    command:
-      - cludod
-      - --port
-      - "8080"
-      - --scheme
-      - http
+    environment:
+      - PORT=8080

--- a/go.mod
+++ b/go.mod
@@ -30,5 +30,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed
 	golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	gopkg.in/ini.v1 v1.62.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-isatty v0.0.13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
+github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -509,6 +511,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/auth/key_utils.go
+++ b/pkg/auth/key_utils.go
@@ -3,8 +3,11 @@ package auth
 import (
 	"crypto/rsa"
 	"fmt"
+	"strings"
+	"syscall"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
 )
 
 func DecodeAuthorizedKey(encoded []byte) (*rsa.PublicKey, error) {
@@ -32,16 +35,41 @@ func EncodeAuthorizedKey(key *rsa.PublicKey) (string, error) {
 	return string(ssh.MarshalAuthorizedKey(pub)), nil
 }
 
+func GetPassphrase() ([]byte, error) {
+	fmt.Printf("\nUnable to decode SSH key on first attempt.\n")
+	fmt.Print("Please enter the correct SSH passphrase: ")
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return []byte(""), err
+	}
+
+	fmt.Printf("\n\n")
+	password := string(bytePassword)
+	return []byte(strings.TrimSpace(password)), nil
+}
+
 func DecodePrivateKey(encoded []byte, password []byte) (*rsa.PrivateKey, error) {
 	var parsedKey interface{}
 	var err error
-	if password != nil {
+
+	// See if we can decode without a passphrase
+	parsedKey, err = ssh.ParseRawPrivateKey(encoded)
+	if err != nil && len(password) == 0 {
+		// if not, let's try the passphrase the user provided
 		parsedKey, err = ssh.ParseRawPrivateKeyWithPassphrase(encoded, password)
-	} else {
-		parsedKey, err = ssh.ParseRawPrivateKey(encoded)
 	}
+	// If we still have an error the passphrase is likely unset or wrong,
+	// so let's prompt for it instead.
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse private key: %v, %#v", err, encoded)
+		var passphrase []byte
+		passphrase, err = GetPassphrase()
+		if err == nil {
+			parsedKey, err = ssh.ParseRawPrivateKeyWithPassphrase(encoded, passphrase)
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse private key: %v", err)
 	}
 
 	privateKey, ok := parsedKey.(*rsa.PrivateKey)

--- a/pkg/auth/key_utils.go
+++ b/pkg/auth/key_utils.go
@@ -43,24 +43,24 @@ func GetPassphrase() ([]byte, error) {
 		return []byte(""), err
 	}
 
-	fmt.Printf("\n\n")
+	fmt.Printf("\n")
 	password := string(bytePassword)
 	return []byte(strings.TrimSpace(password)), nil
 }
 
-func DecodePrivateKey(encoded []byte, password []byte) (*rsa.PrivateKey, error) {
+func DecodePrivateKey(encoded []byte, password []byte, interactive bool) (*rsa.PrivateKey, error) {
 	var parsedKey interface{}
 	var err error
 
 	// See if we can decode without a passphrase
 	parsedKey, err = ssh.ParseRawPrivateKey(encoded)
-	if err != nil && len(password) == 0 {
+	if err != nil && len(password) > 0 {
 		// if not, let's try the passphrase the user provided
 		parsedKey, err = ssh.ParseRawPrivateKeyWithPassphrase(encoded, password)
 	}
 	// If we still have an error the passphrase is likely unset or wrong,
 	// so let's prompt for it instead.
-	if err != nil {
+	if err != nil && interactive == true {
 		var passphrase []byte
 		passphrase, err = GetPassphrase()
 		if err == nil {

--- a/pkg/auth/key_utils.go
+++ b/pkg/auth/key_utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/superorbital/cludo/pkg/utils"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 )
@@ -62,9 +63,13 @@ func DecodePrivateKey(encoded []byte, password []byte, interactive bool) (*rsa.P
 	// so let's prompt for it instead.
 	if err != nil && interactive == true {
 		var passphrase []byte
-		passphrase, err = GetPassphrase()
-		if err == nil {
-			parsedKey, err = ssh.ParseRawPrivateKeyWithPassphrase(encoded, passphrase)
+		if utils.DetectTerminal() == true {
+			passphrase, err = GetPassphrase()
+			if err == nil {
+				parsedKey, err = ssh.ParseRawPrivateKeyWithPassphrase(encoded, passphrase)
+			}
+		} else {
+			fmt.Println("[WARN] No terminal detected. Skipping passphrase prompt.")
 		}
 	}
 

--- a/pkg/auth/key_utils_test.go
+++ b/pkg/auth/key_utils_test.go
@@ -122,7 +122,7 @@ func TestDecodePrivateKey(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, actualErr := auth.DecodePrivateKey(tc.encoded, nil)
+			actual, actualErr := auth.DecodePrivateKey(tc.encoded, nil, false)
 
 			assert.EqualValues(t, tc.want, actual)
 			assert.EqualValues(t, tc.wantErr, actualErr)

--- a/pkg/auth/key_utils_test.go
+++ b/pkg/auth/key_utils_test.go
@@ -2,9 +2,12 @@ package auth_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,13 +26,23 @@ func GenerateSSHAuthorizedKey(t *testing.T) (*rsa.PublicKey, []byte) {
 	return pubKey, ssh.MarshalAuthorizedKey(pub)
 }
 
-func GenerateSSHPrivateKey(t *testing.T) (*rsa.PrivateKey, []byte) {
+func GenerateSSHPrivateKey(t *testing.T, passphrase string) (*rsa.PrivateKey, []byte) {
 	key, _ := GenerateRSAKeyPair(t)
 
 	privateKeyPEM := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}
+
+	var err error
+	// Encrypt the PEM
+	if passphrase != "" {
+		privateKeyPEM, err = x509.EncryptPEMBlock(rand.Reader, privateKeyPEM.Type, privateKeyPEM.Bytes, []byte(passphrase), x509.PEMCipherAES256)
+		if err != nil {
+			return nil, nil
+		}
+	}
+
 	var private bytes.Buffer
 	if err := pem.Encode(&private, privateKeyPEM); err != nil {
 		t.Fatalf("Failed to convert private key to pem format: %v, %#v", err, key)
@@ -104,8 +117,9 @@ func TestDecodePrivateKey(t *testing.T) {
 		wantErr error
 	}
 
-	key1, encoded1 := GenerateSSHPrivateKey(t)
-	key2, encoded2 := GenerateSSHPrivateKey(t)
+	passphrase := ""
+	key1, encoded1 := GenerateSSHPrivateKey(t, passphrase)
+	key2, encoded2 := GenerateSSHPrivateKey(t, passphrase)
 
 	tests := []test{
 		{
@@ -130,4 +144,43 @@ func TestDecodePrivateKey(t *testing.T) {
 	}
 }
 
-// TODO: Add test for private keys with passphrases
+func TestDecodePrivateKeyWithPassPhrase(t *testing.T) {
+	type test struct {
+		name       string
+		encoded    []byte
+		passphrase string
+		want       *rsa.PrivateKey
+		wantErr    error
+	}
+
+	passphrase1 := "cludo123"
+	passphrase2 := "cludo456"
+	key1, encoded1 := GenerateSSHPrivateKey(t, passphrase1)
+	_, encoded2 := GenerateSSHPrivateKey(t, passphrase2)
+
+	tests := []test{
+		{
+			name:       "Test passphrase key 1",
+			encoded:    encoded1,
+			passphrase: "cludo123",
+			want:       key1,
+		},
+		{
+			name:       "Test passphrase key 2",
+			encoded:    encoded2,
+			passphrase: "badpassphrase",
+			want:       nil,
+			wantErr:    errors.New("Failed to parse private key: x509: decryption password incorrect"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt.Println(tc.passphrase)
+			actual, actualErr := auth.DecodePrivateKey(tc.encoded, []byte(tc.passphrase), false)
+
+			assert.EqualValues(t, tc.want, actual)
+			assert.EqualValues(t, tc.wantErr, actualErr)
+		})
+	}
+}

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -16,9 +16,18 @@ import (
 )
 
 type ClientConfig struct {
+<<<<<<< HEAD
 	KeyPath    string `mapstructure:"key_path"`
 	Passphrase string `mapstructure:"passphrase"`
 	ShellPath  string `mapstructure:"shell_path"`
+=======
+	Interactive bool     `mapstructure:"interactive"`
+	ServerURL   string   `mapstructure:"server_url"`
+	KeyPath     string   `mapstructure:"key_path"`
+	Passphrase  string   `mapstructure:"passphrase"`
+	ShellPath   string   `mapstructure:"shell_path"`
+	Roles       []string `mapstructure:"roles"`
+>>>>>>> b6b2438 (non-interactive mode)
 }
 
 func (cc *ClientConfig) NewDefaultSigner() (*auth.Signer, error) {
@@ -45,7 +54,7 @@ func (cc *ClientConfig) NewDefaultSigner() (*auth.Signer, error) {
 	if cc.Passphrase != "" {
 		passphrase = []byte(cc.Passphrase)
 	}
-	key, err := auth.DecodePrivateKey(encodedKey, passphrase)
+	key, err := auth.DecodePrivateKey(encodedKey, passphrase, cc.Interactive)
 	if err != nil {
 		return nil, fmt.Errorf("Failed decoding private key %v: %v", keyPath, err)
 	}

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -16,18 +16,10 @@ import (
 )
 
 type ClientConfig struct {
-<<<<<<< HEAD
-	KeyPath    string `mapstructure:"key_path"`
-	Passphrase string `mapstructure:"passphrase"`
-	ShellPath  string `mapstructure:"shell_path"`
-=======
-	Interactive bool     `mapstructure:"interactive"`
-	ServerURL   string   `mapstructure:"server_url"`
-	KeyPath     string   `mapstructure:"key_path"`
-	Passphrase  string   `mapstructure:"passphrase"`
-	ShellPath   string   `mapstructure:"shell_path"`
-	Roles       []string `mapstructure:"roles"`
->>>>>>> b6b2438 (non-interactive mode)
+	Interactive bool   `mapstructure:"interactive"`
+	KeyPath     string `mapstructure:"key_path"`
+	Passphrase  string `mapstructure:"passphrase"`
+	ShellPath   string `mapstructure:"shell_path"`
 }
 
 func (cc *ClientConfig) NewDefaultSigner() (*auth.Signer, error) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"os"
+	"runtime"
+
+	isatty "github.com/mattn/go-isatty"
+)
+
+func DetectTerminal() bool {
+	var session bool
+	if runtime.GOOS == "windows" {
+		// Detect the newer Windows Terminal
+		_, session = os.LookupEnv("WT_SESSION")
+	} else {
+		session = false
+	}
+	// Detect Unix and Cygwin Terminals
+	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) || session == true {
+		return true
+	} else {
+		return false
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"flag"
+	"testing"
+)
+
+var term = flag.Bool("terminal", false, "Is a terminal available?")
+
+func TestDetectTerminal(t *testing.T) {
+
+	if DetectTerminal() == true {
+		if *term != true {
+			t.Error("[ERROR] terminal flag is false, but a terminal was detected")
+		}
+	} else {
+		if *term == true {
+			t.Error("[ERROR] terminal flag is true, but no terminal was detected")
+		}
+	}
+}


### PR DESCRIPTION
**closes:** https://github.com/superorbital/cludo/issues/30

This adds an interactive prompt for the SSH key passphrase when the system is having trouble decoding the key.

It also adds an interactive CLI switch which can be used to disable the prompting for scripts, etc.