### PR TITLE
Use pre-build hub-tool binary (from our fork)

### DIFF
--- a/.github/workflows/pr_closed.yaml
+++ b/.github/workflows/pr_closed.yaml
@@ -11,8 +11,8 @@ jobs:
         # https://github.com/docker/hub-tool/pull/198
         # https://github.com/docker/hub-tool/issues/58#issuecomment-1006058934
         run: |
-          curl -sL https://github.com/superorbital/docker-hub-tool/releases/download/2022-01-06-patched/hub-tool_linux_amd64 -o /usr/bin/hub-tool
-          chmod a+rx /usr/bin/hub-tool
+          sudo curl -sL https://github.com/superorbital/docker-hub-tool/releases/download/2022-01-06-patched/hub-tool_linux_amd64 -o /usr/bin/hub-tool
+          sudo chmod a+rx /usr/bin/hub-tool
       - name: Remove PR container image via hub-tool
         run: |
           /usr/bin/hub-tool login

--- a/.github/workflows/pr_closed.yaml
+++ b/.github/workflows/pr_closed.yaml
@@ -6,73 +6,12 @@ jobs:
   pr-closure-cleanup:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.5' # The Go version to download and use.
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN}}
       - name: Install Docker hub-tool
         # Migrate back to the official release once something like these changes are merged:
         # https://github.com/docker/hub-tool/pull/198
         # https://github.com/docker/hub-tool/issues/58#issuecomment-1006058934
         run: |
-          #curl -sO $(curl -sL https://api.github.com/repos/docker/hub-tool/releases/latest | jq -r '.assets[].browser_download_url' | grep linux-amd64.tar.gz) | tar -xz  -C /usr/bin
-          git clone https://github.com/docker/hub-tool.git
-          cd hub-tool
-          git checkout c9cb0ac822ad431a252d462d80ab0dcc21d49e6f
-          cat << "EOF" > fixes.patch
-          diff -ur hub-tool/internal/commands/tag/rm.go hub-tool-envlogin/internal/commands/tag/rm.go
-          --- hub-tool/internal/commands/tag/rm.go	2022-01-05 13:04:09.000000000 -0800
-          +++ hub-tool-envlogin/internal/commands/tag/rm.go	2022-01-05 13:04:58.000000000 -0800
-          @@ -96,7 +96,12 @@
-           	}
-          
-           	if err := hubClient.RemoveTag(reference.FamiliarName(ref), ref.Tag()); err != nil {
-          -		return err
-          +		if strings.Contains(err.Error(), "404 NOT FOUND") {
-          +			fmt.Fprintln(streams.Out(), "Not Found", image)
-          +			return nil
-          +		} else {
-          +			return err
-          +		}
-           	}
-           	fmt.Fprintln(streams.Out(), "Deleted", image)
-           	return nil
-          diff -ur hub-tool/internal/login/login.go hub-tool-envlogin/internal/login/login.go
-          --- hub-tool/internal/login/login.go	2022-01-05 13:04:09.000000000 -0800
-          +++ hub-tool-envlogin/internal/login/login.go	2022-01-05 10:18:07.000000000 -0800
-          @@ -40,14 +40,20 @@
-           func RunLogin(ctx context.Context, streams command.Streams, hubClient *hub.Client, store credentials.Store, candidateUsername string) error {
-           	username := candidateUsername
-           	if username == "" {
-          +		username = os.Getenv("DOCKER_USERNAME")
-          +	}
-          +	if username == "" {
-           		var err error
-           		if username, err = readClearText(ctx, streams, "Username: "); err != nil {
-           			return err
-           		}
-           	}
-          -	password, err := readPassword(streams)
-          -	if err != nil {
-          -		return err
-          +	password := os.Getenv("DOCKER_PASSWORD")
-          +	if password == "" {
-          +		var err error
-          +		if password, err = readPassword(streams); err != nil {
-          +			return err
-          +		}
-           	}
-          
-           	token, refreshToken, err := Login(ctx, streams, hubClient, username, password)
-          EOF
-          patch -s -p1 < ./fixes.patch
-          make
-          sudo mv bin/hub-tool /usr/bin/hub-tool
+          curl -sL https://github.com/superorbital/docker-hub-tool/releases/download/2022-01-06-patched/hub-tool_linux_amd64 -o /usr/bin/hub-tool
           chmod a+rx /usr/bin/hub-tool
       - name: Remove PR container image via hub-tool
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -122,8 +122,5 @@ The workflow looks something like this:
 The workflow looks something like this:
 
 * On any PR closure:
-  * Set up `qemu` and `binfmt` to support multi-architecture container image builds.
-  * Setup `go` environment.
-  * Run `docker login`
-  * Patch and Build Docker 's `hub-tool`
+  * Install a fork of Docker 's `hub-tool`
   * Remove all PR-related container images via `hub-tool`


### PR DESCRIPTION

This pulls the patches out of here and relies on a centralized fork of Docker's hub-tool