### PR TITLE
Make local dev easier and fix some initial bugs

### DIFF
--- a/docker/entrypoint-cludod.sh
+++ b/docker/entrypoint-cludod.sh
@@ -13,7 +13,7 @@ if [ -z "${PORT}" ]; then
 fi
 
 if [ -z "${@}" ]; then
-    cludod --port=${PORT} --scheme=http --host=0.0.0.0
+    cludod --config=/etc/cludod/cludod.yaml --port=${PORT} --scheme=http --host=0.0.0.0
 else
     ${@}
 fi

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -6,29 +6,32 @@ It is easy to install the cludo server (cludod) using either [kubectl](https://k
 
 * **Note**: You must provide a `cludod.yaml` that contains your real secrets. At the moment `kustomize` looks for a `.gitignored` file here: `k8s/kustomize/base/files-secrets/secret-cludod.yaml`. You can find an example of what this file should look like here: `k8s/kustomize/base/files-secrets/cludod-EXAMPLE.yaml`
 
-* With recent `kubectl` releases
+* View manifests with recent `kubectl` releases
+  * Note that there are multiple overlays. Apply the one appropriate to your use case.
 
 ```sh
-kubectl kustomize k8s/kustomize/base
 kubectl kustomize k8s/kustomize/overlays/development
-kubectl kustomize k8s/kustomize/overlays/staging
-kubectl kustomize k8s/kustomize/overlays/production
 ```
 
-* With `kustomize` 4+
+* View manifests with `kustomize` 4+
 
 ```sh
-kustomize build k8s/kustomize/base
 kustomize build k8s/kustomize/overlays/development
-kustomize build k8s/kustomize/overlays/staging
-kustomize build k8s/kustomize/overlays/production
+```
+
+* Apply and delete manifests with recent `kubectl` releases
+
+```sh
+kubectl apply -k k8s/kustomize/overlays/development/
+kubectl delete -k k8s/kustomize/overlays/development/
 ```
 
 ## helm
 
-* With `helm` 3+
+* Apply and delete manifest with `helm` 3+
 
 ```
 helm repo add superorbital https://helm.superorbital.io/
 helm install cludod superorbital/cludod
+helm uninstall cludod
 ```

--- a/k8s/kustomize/base/cludod-deployment.yaml
+++ b/k8s/kustomize/base/cludod-deployment.yaml
@@ -35,11 +35,11 @@ spec:
               protocol: TCP
         livenessProbe:
           httpGet:
-            path: /
+            path: /v1/health
             port: http
         readinessProbe:
           httpGet:
-            path: /
+            path: /v1/health
             port: http
         volumeMounts:
         - name: config

--- a/k8s/kustomize/overlays/local/kustomization.yaml
+++ b/k8s/kustomize/overlays/local/kustomization.yaml
@@ -1,0 +1,9 @@
+commonLabels:
+ env: development
+bases:
+- ../../base
+patches:
+- replica_count.yaml
+images:
+- name: superorbital/cludod:latest
+  newTag: local

--- a/k8s/kustomize/overlays/local/replica_count.yaml
+++ b/k8s/kustomize/overlays/local/replica_count.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cludod
+spec:
+  replicas: 1


### PR DESCRIPTION
This adds some support for a `containerd` based workflow in local dev.

It also fixes:
* The health endpoint used in the deployment manifest
* The config file name that the cludod container looks for by default

