### PR TITLE
Fix tag detection logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Get Last Version from Tag
         id: lasttag
         shell: bash
-        run: echo ::set-output name=version::$(git describe --abbrev=0 --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*' | cut -c2-)
+        run: echo ::set-output name=version::$(git describe --abbrev=0 --tags --match '*[0-9]*\.[0-9]*\.[0-9]*')
 
       - name: Parse Changelog
         id: changelog


### PR DESCRIPTION
This should fix the tag detection logic, so that we don't recreate and announce releases that have already been done.

Fixes #79 