### PR TITLE
Fix config log issue with cludod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PR_NUM ?= ""
 all: test build docker
 .PHONY: all swagger build test clean docker docker-local-arch-build nerdctl nerdctl-local-arch-build
 
-all-nerdctl: test build nerdctl
+all-nc: test build nerdctl
 
 swagger:
 	./bin/gen-swagger.sh

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -69,13 +69,16 @@ func ConfigureViper(executable string, configFile string) error {
 		}
 	}
 	// local repo cludo.yaml file
-	viper.SetConfigName("cludo")
-	viper.AddConfigPath(".")
-	if err := viper.MergeInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			return ErrConfigNotFound
-		} else {
-			return ErrConfigLoadFailed(err)
+	// Only check for this when we are using the client.
+	if executable == "cludo" {
+		viper.SetConfigName("cludo")
+		viper.AddConfigPath(".")
+		if err := viper.MergeInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				return ErrConfigNotFound
+			} else {
+				return ErrConfigLoadFailed(err)
+			}
 		}
 	}
 	return nil

--- a/restapi/configure_cludod.go
+++ b/restapi/configure_cludod.go
@@ -65,8 +65,8 @@ func configureAPI(api *operations.CludodAPI) http.Handler {
 	api.APIKeyHeaderAuth = func(token string) (*models.ModelsPrincipal, error) {
 		conf, err := config.NewConfigFromViper()
 		if err != nil {
-			api.Logger("ERROR: Failed to read cludo configuration: %v", err)
-			return nil, errors.New(500, "Failed to read cludo configuration: %v", err)
+			api.Logger("ERROR: Failed to read cludod configuration: %v", err)
+			return nil, errors.New(500, "Failed to read cludod configuration: %v", err)
 		}
 
 		api.Logger("DEBUG: Read in viper config: %#v", conf)
@@ -101,7 +101,7 @@ func configureAPI(api *operations.CludodAPI) http.Handler {
 	api.EnvironmentGenerateEnvironmentHandler = environment.GenerateEnvironmentHandlerFunc(func(params environment.GenerateEnvironmentParams, principal *models.ModelsPrincipal) middleware.Responder {
 		conf, err := config.NewConfigFromViper()
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to read cludo configuration: %v", err)
+			errMsg := fmt.Sprintf("Failed to read cludod configuration: %v", err)
 			api.Logger("ERROR: %s", err)
 			return environment.NewGenerateEnvironmentDefault(500).WithPayload(&models.Error{
 				Code:    500,
@@ -187,7 +187,7 @@ func configureAPI(api *operations.CludodAPI) http.Handler {
 	api.RoleListRolesHandler = role.ListRolesHandlerFunc(func(params role.ListRolesParams, principal *models.ModelsPrincipal) middleware.Responder {
 		conf, err := config.NewConfigFromViper()
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to read cludo configuration: %v", err)
+			errMsg := fmt.Sprintf("Failed to read cludod configuration: %v", err)
 			api.Logger("ERROR: %s", err)
 			return role.NewListRolesDefault(500).WithPayload(&models.Error{
 				Code:    500,


### PR DESCRIPTION
Fixes #77 

As it turned out the error was "correct" but very mis-leading. When logic was added for the client to merge in a local `cludo.yaml` file from the current directory (git repo), it did not take into account that this logic would also be applied on the server, and the error that is generated on the server is confusing. This fixes that.